### PR TITLE
Invert social icons with dark/light mode switch

### DIFF
--- a/sass/parts/_header.scss
+++ b/sass/parts/_header.scss
@@ -102,7 +102,11 @@ header .main {
   border: unset;
   width: 24px;
   height: 24px;
+  filter: invert(1);
+  }
 
+[data-theme="light"] .social>img {
+  filter: invert(0);
 }
 
 .meta {


### PR DESCRIPTION
This change makes it so social icons always have good contrast with both dark and light mode.

It accomplishes this by adding the data attribute [data-theme="light"] and enabling/disabling the invert filter on dark and light .social images.

![dark](https://user-images.githubusercontent.com/6399341/216044927-baf8c05e-114c-4169-9c99-d5454a97c216.png)
![light](https://user-images.githubusercontent.com/6399341/216044933-eab83402-a335-43ed-96bb-110d95964000.png)