### PR TITLE
Remove check for dark/light mode to invert social icons

### DIFF
--- a/sass/parts/_header.scss
+++ b/sass/parts/_header.scss
@@ -113,9 +113,3 @@ header .main {
   color: var(--meta-color);
   letter-spacing: -0.5px;
 }
-
-@media (prefers-color-scheme: dark) {
-  .social>img {
-    filter: invert(1);
-  }
-}


### PR DESCRIPTION
The lines removed check for the user's light/dark mode and set the `invert` filter on the social icons.

This is unnecessary, as the inversion already happens when setting the light/dark modes using the switch.