### PR TITLE
fix: prevent word splitting

### DIFF
--- a/templates/partials/footer.html
+++ b/templates/partials/footer.html
@@ -17,4 +17,3 @@
     </section>
     <script src="{{ get_url(path='js/main.js', trailing_slash=false) | safe }}"/></script>
 </footer>
-

--- a/templates/partials/footer.html
+++ b/templates/partials/footer.html
@@ -4,7 +4,7 @@
             {%- if config.extra.socials %}
             {% for social in config.extra.socials %}
             <a rel="noopener noreferrer" target="_blank" class="nav-links social" href="{{ social.url }}">
-                <img alt={{ social.name }} title={{ social.name }} src="/social_icons/{{ social.icon }}.svg">
+                <img alt="{{ social.name }}" title="{{ social.name }}" src="/social_icons/{{ social.icon }}.svg">
             </a>
             {% endfor %}
             {% endif %}

--- a/templates/partials/footer.html
+++ b/templates/partials/footer.html
@@ -17,3 +17,4 @@
     </section>
     <script src="{{ get_url(path='js/main.js', trailing_slash=false) | safe }}"/></script>
 </footer>
+


### PR DESCRIPTION
Thanks for the theme! I also use it - https://algomaster99.github.io/.

The changes fix word splitting in footer icons. Otherwise `name = "Google Scholar"` is rendered as `alt="Google"` only.